### PR TITLE
Add basic support for building against custom USD library prefixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,10 @@ set(HOUDINI_PATH ""
     "The path to the Houdini installation. This is optional if the HFS environment variable is set.")
 set(BOOST_NAMESPACE "boost"
     CACHE STRING
-    "The namespace of the Boost build you are using with USD")
+    "The namespace of the Boost build you are using with USD.")
+set(USD_LIB_PREFIX "lib"
+    CACHE STRING
+    "The name prefix of the USD libraries to build/link against.")
 option(COPY_HOUDINI_USD_PLUGINS "Copy $HH/dso/usd_plugins from Houdini to the project installation directory" ON)
 
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake)

--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ The following variables are used to configure the CMake build:
 * HOUDINI_PATH: The path to the root of the Houdini install. If this is
   omitted, the $HFS environment variable will be checked as well.
 * USD_ROOT: The path to the USD install.
+* USD_LIB_PREFIX: The naming prefix of the USD libraries to build/link against.
+  This should match the value of the `PXR_LIB_PREFIX` CMake variable used to
+  build USD, and defaults to "lib" (which matches the USD build default).
 * BOOST_NAMESPACE: The namespace of the Boost build used by the external USD
   build. This defaults to "boost".
 * COPY_HOUDINI_USD_PLUGINS: Whether to copy the $HH/dso/usd_plugins directory

--- a/cmake/FindUSD.cmake
+++ b/cmake/FindUSD.cmake
@@ -8,7 +8,7 @@ find_path(USD_INCLUDE_DIR pxr/pxr.h
           PATHS ${USD_ROOT}/include
           DOC "USD Include directory")
 
-find_path(USD_LIBRARY_DIR libusd.so
+find_path(USD_LIBRARY_DIR "${USD_LIB_PREFIX}usd${CMAKE_SHARED_LIBRARY_SUFFIX}"
           PATHS ${USD_ROOT}/lib
           DOC "USD Libraries directory")
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,7 +18,7 @@ add_compile_definitions(${_houdini_defines})
 
 # Libs we will link with from the Houdini install
 if (WIN32)
-    set(houdini_LINK_LIBS 
+    set(houdini_LINK_LIBS
 	libHOMUI
 	libFUSE
 	libMT
@@ -174,10 +174,10 @@ else()
 	openvdb_sesi
 	tbb)
 endif()
-# Iex)
+
 
 # Libs we will link with from the external USD install
-set(usd_LINK_LIBS
+set(usd_LINK_LIB_NAMES
     ar
     arch
     garch
@@ -211,7 +211,21 @@ set(usd_LINK_LIBS
     work)
 
 # The complete set of libs we need to link against
-set(HUSD_LINK_LIBS ${houdini_LINK_LIBS} ${usd_LINK_LIBS})
+set(HUSD_LINK_LIBS ${houdini_LINK_LIBS})
+
+# Strip any platform-specific library prefix from USD_LIB_PREFIX to get the
+# library name prefix to use in linker commands.
+set(usd_LIB_LINK_PREFIX ${USD_LIB_PREFIX})
+if (CMAKE_SHARED_LIBRARY_PREFIX AND USD_LIB_PREFIX MATCHES "^${CMAKE_SHARED_LIBRARY_PREFIX}.*")
+    string(LENGTH ${CMAKE_SHARED_LIBRARY_PREFIX} _lib_prefix_length)
+    string(SUBSTRING ${USD_LIB_PREFIX} ${_lib_prefix_length} -1 usd_LIB_LINK_PREFIX)
+endif()
+
+# Convert base USD library names to their actual names based on the prefix
+# computed above, and append the qualified names to HUSD_LINK_LIBS.
+foreach (libname ${usd_LINK_LIB_NAMES})
+    list(APPEND HUSD_LINK_LIBS "${usd_LIB_LINK_PREFIX}${libname}")
+endforeach()
 
 include_directories(
     ${USD_INCLUDE_DIR}


### PR DESCRIPTION
This adds support for building against USD libraries with a custom naming prefix via a new `USD_LIB_PREFIX` build variable.