### PR TITLE
Update build to suppress some more warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,9 @@ else()
     find_path(HOUDINI_ROOT dsolib/libHoudiniAPPS3${CMAKE_SHARED_LIBRARY_SUFFIX}
 		HINTS ${HOUDINI_PATH} ENV HFS
 		NO_DEFAULT_PATH)
-	set(PLATFORM_CXX_OPTIONS "-Wno-missing-field-initializers")
+	set(PLATFORM_CXX_OPTIONS
+        -Wno-missing-field-initializers
+        -Wno-unused-function)
 	set(PLATFORM_LINK_OPTIONS "-Wl,--exclude-libs,ALL")
 endif()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -241,12 +241,14 @@ foreach (libname ${usd_LINK_LIB_NAMES})
     list(APPEND HUSD_LINK_LIBS "${usd_LIB_LINK_PREFIX}${libname}")
 endforeach()
 
+# Marking these as SYSTEM suppresses the needless warnings they generate.
+include_directories(SYSTEM
+    ${Boost_INCLUDE_DIR}
+    ${PYTHON_INCLUDE_DIRS})
 
 include_directories(
     ${USD_INCLUDE_DIR}
     houdini/lib/H_USD
-    ${Boost_INCLUDE_DIR}
-    ${PYTHON_INCLUDE_DIRS}
     ${HOUDINI_INCLUDE_DIR})
 
 if (WIN32)


### PR DESCRIPTION
Some minor updates to the build process to cut down on the amount of external warning noise.

- Mark Python and Boost include directories as `SYSTEM`
- Suppress `unused-function` warnings