### PR TITLE
Fixed initial value of myConformPolicy class variable in HUSD_Imaging

### DIFF
--- a/src/houdini/lib/H_USD/HUSD/HUSD_Imaging.C
+++ b/src/houdini/lib/H_USD/HUSD/HUSD_Imaging.C
@@ -271,7 +271,7 @@ HUSD_Imaging::HUSD_Imaging()
     mySettingsChanged = true;
     myValidRenderSettingsPrim = false;
     myCameraSynced = true;
-    myConformPolicy = HUSD_Scene::EXPAND_APERTURE;
+    myConformPolicy = CameraUtilFit;  // corresponds to HUSD_Scene::EXPAND_APERTURE
     myFrame = -1e30;
     myScene = nullptr;
     myCompositor = nullptr;


### PR DESCRIPTION
Houdini translates between its own conform policy values and those used by Hydra. However, in this instance, the value of myConformPolicy was supposed to be a Hydra enum, but was set using the HUD_Scene enum. This causes the "free" camera to have the incorrect conform policy set.