### PR TITLE
Missing boost hash include when using a different boost library than hboost

### DIFF
--- a/src/houdini/custom/USD/GEO_FilePrimInstancerUtils.C
+++ b/src/houdini/custom/USD/GEO_FilePrimInstancerUtils.C
@@ -22,6 +22,8 @@
 #include <GU/GU_PackedDisk.h>
 #include <GU/GU_PackedFragment.h>
 
+#include BOOST_HEADER(functional/hash.hpp)
+
 PXR_NAMESPACE_OPEN_SCOPE
 
 const GT_PackedInstanceKey GTnotInstancedKey(-1);


### PR DESCRIPTION
HoudiniUsdBridge doesn't build, on linux, against houdini 20.0.597, _not using hboost_, without this change. It _does_ build without this change, _when using hboost_.

The build environment is CentOS-7.8, devtoolset 9, python-3.9, boost-1.76 and a build of USD using https://github.com/sideeffects/USD/tree/dev_houdini20.0

There has been a fair bit of work in USD between 22.05 and 23.08, replacing boost::hash includes. I suspect that's the reason why it works with older versions of houdini/USD: `boost/functional/hash` was probably transitively carried over via some USD headers.