### PR TITLE
Fixed problems with Hydra render delegates during launch of Houdini

### DIFF
--- a/src/houdini/custom/USDUI/XUSD_ImagingEngineGL.C
+++ b/src/houdini/custom/USDUI/XUSD_ImagingEngineGL.C
@@ -252,7 +252,7 @@ _CopyRenderParams(const XUSD_ImagingRenderParams &src,
 // Construction
 //----------------------------------------------------------------------------
 
-XUSD_ImagingEngineGL::XUSD_ImagingEngineGL(
+XUSD_ImagingEngineGL::XUSD_ImagingEngineGL(const TfToken& rendererPluginId,
         bool force_null_hgi, bool use_scene_indices)
     : _hgi()
     , _hgiDriver()
@@ -268,17 +268,21 @@ XUSD_ImagingEngineGL::XUSD_ImagingEngineGL(
 {
     RE_Wrapper wrapper(true);
 
-    if (wrapper.isOpenGLAvailable())
-        _InitGL();
-
+    // Hgi must be initialized before the renderer plugin is set.
     _InitializeHgiIfNecessary(force_null_hgi);
-    
+
     // _renderIndex, _taskController, and _sceneDelegate are initialized
     // by the plugin system.
-    if (!SetRendererPlugin(_GetDefaultRendererPluginId())) {
+    if (!SetRendererPlugin(!rendererPluginId.IsEmpty() ?
+            rendererPluginId : _GetDefaultRendererPluginId())) {
         TF_CODING_ERROR("No renderer plugins found! "
                         "Check before creation.");
     }
+
+    // GL must be initialized after the renderer plugin has been set, because
+    // the renderer plugin updates the GlfGLContextRegistry.
+    if (wrapper.isOpenGLAvailable())
+        _InitGL();
 }
 
 bool

--- a/src/houdini/custom/USDUI/XUSD_ImagingEngineGL.h
+++ b/src/houdini/custom/USDUI/XUSD_ImagingEngineGL.h
@@ -56,7 +56,8 @@ TF_DECLARE_REF_PTRS(HdSceneIndexBase);
 class XUSD_ImagingEngineGL : public XUSD_ImagingEngine
 {
 public:
-    XUSD_ImagingEngineGL(bool force_null_hgi, bool use_scene_indices);
+    XUSD_ImagingEngineGL(const TfToken& rendererPluginId,
+                bool force_null_hgi, bool use_scene_indices);
     ~XUSD_ImagingEngineGL() override;
 
     // Check if the GL being used by USD imaging is running in core profile.

--- a/src/houdini/custom/USDUI/plugin.C
+++ b/src/houdini/custom/USDUI/plugin.C
@@ -16,6 +16,7 @@
 
 #include "XUSD_ImagingEngineGL.h"
 #include <UT/UT_DSOVersion.h>
+#include <UT/UT_String.h>
 #include <SYS/SYS_Version.h>
 #include <SYS/SYS_Visibility.h>
 
@@ -23,9 +24,10 @@ extern "C"
 {
     SYS_VISIBILITY_EXPORT extern
     PXR_NS::XUSD_ImagingEngine *
-    newImagingEngine(bool force_null_hgi, bool use_scene_indices)
+    newImagingEngine(const UT_StringRef &renderer,
+            bool force_null_hgi, bool use_scene_indices)
     {
-        return new PXR_NS::XUSD_ImagingEngineGL(
+        return new PXR_NS::XUSD_ImagingEngineGL(PXR_NS::TfToken(renderer),
             force_null_hgi, use_scene_indices);
     }
 }

--- a/src/houdini/lib/H_USD/HUSD/HUSD_Imaging.C
+++ b/src/houdini/lib/H_USD/HUSD/HUSD_Imaging.C
@@ -745,7 +745,8 @@ HUSD_Imaging::setupRenderer(const UT_StringRef &renderer_name,
         bool drawmode = theRendererInfoMap[myRendererName].drawModeSupport();
 
 	myPrivate->myImagingEngine =
-            XUSD_ImagingEngine::createImagingEngine(false,
+            XUSD_ImagingEngine::createImagingEngine(myRendererName,
+                false /*force_null_hgi*/,
                 (HoudiniGetenv(theEnableSceneIndexEnvVar) &&
                  SYSatoi(HoudiniGetenv(theEnableSceneIndexEnvVar)) != 0));
         if (!myPrivate->myImagingEngine)

--- a/src/houdini/lib/H_USD/HUSD/XUSD_ImagingEngine.C
+++ b/src/houdini/lib/H_USD/HUSD/XUSD_ImagingEngine.C
@@ -35,10 +35,11 @@
 
 PXR_NAMESPACE_OPEN_SCOPE
 
-typedef XUSD_ImagingEngine *(*XUSD_ImagingEngineCreator)(bool, bool);
+typedef XUSD_ImagingEngine *(*XUSD_ImagingEngineCreator)
+        (const UT_StringRef&, bool, bool);
 
 UT_UniquePtr<XUSD_ImagingEngine>
-XUSD_ImagingEngine::createImagingEngine(
+XUSD_ImagingEngine::createImagingEngine(const UT_StringRef& renderer,
         bool force_null_hgi, bool use_scene_indices)
 {
     static XUSD_ImagingEngineCreator theCreator;
@@ -73,7 +74,7 @@ XUSD_ImagingEngine::createImagingEngine(
 
     UT_ASSERT(theCreator);
     return UT_UniquePtr<XUSD_ImagingEngine>(
-        theCreator(force_null_hgi, use_scene_indices));
+        theCreator(renderer, force_null_hgi, use_scene_indices));
 }
 
 XUSD_ImagingEngine::XUSD_ImagingEngine()

--- a/src/houdini/lib/H_USD/HUSD/XUSD_ImagingEngine.h
+++ b/src/houdini/lib/H_USD/HUSD/XUSD_ImagingEngine.h
@@ -134,6 +134,7 @@ public:
     // Static function for creating XUSD_ImagingeEngine objects.
     // The real implementation of this class is in $SHC/USDUI.
     static UT_UniquePtr<XUSD_ImagingEngine> createImagingEngine(
+            const UT_StringRef& renderer,
             bool force_null_hgi, bool use_scene_indices);
 
     // Disallow copies


### PR DESCRIPTION
There are a couple of issues I noticed with the setting of the Hydra render delegate when Houdini is launched.

First, XUSD_ImagingEngineGL::SetRendererPlugin() is called numerous times with the renderer ping-ponging between the default renderer (HD_HoudiniRendererPlugin aka Houdini GL), and our custom render delegate (ChmRendererPlugin aka Chimera). This causes the render delegates (and their associated plugins) to be constructed and destructed multiple times.

The big problem we were having with this was that during the construction, destruction, and setting of render delegates (and their associated plugins), a shared context is created which subsequently becomes invalid when the plugin that created it is destructed. And since the shared context can only be initialized once (see GlfGLContextRegistry::GetShared()) every time somebody wants to use it, they get an invalid context.

The underlying problems and solutions are twofold:
1. The XUSD_ImagingEngineGL constructor was calling _InitGL() (which creates the shared context) before the GlfGLContextRegistry (which is used to create the shared context) had been initialized. The fix for this was to move the call to _InitGL() to the end of the constructor.
2. The XUSD_ImagingEngineGL constructor was always setting the renderer plugin to the default (which is HD_HoudiniRendererPlugin) and this was later being changed to the desired renderer plugin in HUSD_Imaging::setupRenderer(). The fix for this was to pass the desired renderer plugin (name) to the XUSD_ImagingEngineGL constructor from HUSD_Imaging::setupRenderer().